### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Then, set your passcode to the form. The passcode store on the form between requ
 
 During the process of uploading, your files will be encrypt and their EXT change to `.crypt`
 
-When files lying on your server, their data is crypted.
+When files lying on your server, their data is encrypted.
 
 If you need decrypt any `.crypt` flles, set your passcode, and click on file. During download this file, it will be decrypt on the fly.
 
@@ -258,7 +258,7 @@ https://github.com/western/http-here/issues
 - [ ] add --log and --tee args for save output (or database?)
 - [ ] change background actions for FS drivers (i need one abstraction layer)
 - [ ] problem: how decide to run md5sum inside some folder
-- [ ] database, seperate branch without?
+- [ ] database, separate branch without?
 - [ ] tests
 
 ### 1.11.0

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	arg_folder_make_disable := flag.Bool("folder-make-disable", false, "Disable make folder API and form controller")
 	arg_index_disable := flag.Bool("index-disable", false, "Disable current folder read")
 
-	arg_extend_mode := flag.Bool("extend-mode", false, "Enable delete mechanics. Be very carefull. It disabled by default.")
+	arg_extend_mode := flag.Bool("extend-mode", false, "Enable delete mechanics. Be very careful. It disabled by default.")
 	arg_crypt := flag.Bool("crypt", false, "Enable file crypt support.")
 	arg_spa := flag.Bool("spa", false, "Enable frontend SPA (Single Page Application)")
 
@@ -122,7 +122,7 @@ func main() {
 			`     Only share`,
 			`                        ` + green_clr(`http-here`) + ` --upload-disable --folder-make-disable ` + white_clr(`/tmp/fold`),
 			``,
-			`     Powerfull`,
+			`     Powerful`,
 			`                        ` + green_clr(`http-here`) + ` --tls --user ` + white_clr(`user`+controller.RandStringRunes(2)) + ` --password ` + white_clr(controller.RandStringRunes(12)) + ` --prefork ` + white_clr(`/tmp/fold`),
 			``,
 		}


### PR DESCRIPTION
Found via `codespell -S *.js`